### PR TITLE
Fix/stelable from gui

### DIFF
--- a/src/main/java/com/lunar_prototype/deepwither/PlayerInventoryRestrictor.java
+++ b/src/main/java/com/lunar_prototype/deepwither/PlayerInventoryRestrictor.java
@@ -80,10 +80,11 @@ public class PlayerInventoryRestrictor implements Listener {
 
                     if (slot < HOTBAR_HEAD || HOTBAR_TAIL < slot) {
                         var isWeapon = isWeapon(source);
+                        var hasWeaponInHotbar = hasWeaponInHotbar(inventory);
 
-                        applyStrategy(isWeapon && hasWeaponInHotbar(inventory) ? CANCEL : QUICKMOVE, inventory, source);
+                        applyStrategy(isWeapon && hasWeaponInHotbar ? CANCEL : QUICKMOVE, inventory, source);
 
-                        if (isWeapon && !source.isEmpty()) {
+                        if (isWeapon && !source.isEmpty() && hasWeaponInHotbar) {
                             player.sendMessage(MULTIPLE_WEAPONS);
                         }
 


### PR DESCRIPTION
クイック移動時の制限に対応するguiの範囲を縮小
ホットバーの武器数制限を貫通できる操作は増えるけどGUIからアイテムを盗むことはなくなるはず

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * インベントリ操作時の条件判定を簡潔化し、処理対象が限定されるようになりました（プレイヤー側のクラフト画面からの移動に限定）。

* **バグ修正**
  * 武器の自動移動／クイック移動の挙動を見直し、ホットバーに武器がある場合の処理がより一貫しました。
  * 複数武器検出時の通知出力が条件に合わせて正しく発火するよう修正しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->